### PR TITLE
Avoid crash caused by long messages without spaces

### DIFF
--- a/src/main/java/chronometry/MonsterMessageRepeater.java
+++ b/src/main/java/chronometry/MonsterMessageRepeater.java
@@ -22,7 +22,11 @@ public class MonsterMessageRepeater {
 						if (m.name.split(" ")[0].toLowerCase().equals(username.split(" ")[0].toLowerCase())) {
 							msg = msg.substring(0, Math.min(msg.length(), MonsterMessageRepeater.MsgLength));
 							if (msg.length() == MonsterMessageRepeater.MsgLength) {
-								msg = msg.substring(0, msg.lastIndexOf(" ")) + "...";
+								int lastSpacePos = msg.lastIndexOf(" ");
+								if (lastSpacePos != -1) {
+									msg = msg.substring(0, lastSpacePos);
+								}
+								msg += "...";
 							}
 							AbstractDungeon.effectList.add(new SpeechBubble(m.hb.cX + m.dialogX, m.hb.cY + m.dialogY, 5.0F, msg, false));
 						}


### PR DESCRIPTION
If a long message contains no spaces (like a link) lastIndexOf will return -1. In that case the call to substring() will throw a IndexOutOfBoundsException and crash the game.

To fix, we check whether the lastIndexOf found any spaces. If it did use the old logic. If it doesn't then just append ... to the end of the string. Note that this means that we can end up with something like mylongmessage... without a space between the message and the ellipsis.

This bug caused a crash during a stream by https://www.twitch.tv/tsm_theoddone last night.